### PR TITLE
polling rate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/comet.c
+++ b/src/comet.c
@@ -19,6 +19,7 @@ void print_help() {
     printf("\nusage: comet (path) [flags]\n");
     printf("\n-debug               launch window with debug interface");
     printf("\n-max-cycles:[int]    halt after cycle count has been reached (will run forever if unset)");
+    printf("\n-polling-rate:[int]  use a custom polling rate for user input, every [input] cycles (0 = never poll, default 4096)");
     printf("\n-memory:[int]        use a custom address space size; the maximum addressable byte will be [int]-1");
     printf("\n                     if not provided, defaults to 2^26 (64 MiB)");
     printf("\n-bench               output benchmark info after execution is halted");
@@ -42,6 +43,7 @@ cmd_arg make_argument(char* s) {
 }
 
 void load_arguments(int argc, char* argv[]) {
+    comet.flag_polling_rate = 4096;
     if (argc < 2) {
         print_help();
         exit(EXIT_SUCCESS);
@@ -61,6 +63,8 @@ void load_arguments(int argc, char* argv[]) {
                 printf("error: expected positive int, got \"%s\"\n", a.val);
                 exit(EXIT_FAILURE);
             }
+        } else if(!strcmp(a.key, "-polling-rate")) {
+            comet.flag_polling_rate = strtoull(a.val, NULL, 0);
         } else if (!strcmp(a.key, "-memory")) {
             comet.mmu.mem_max = strtoull(a.val, NULL, 0);
             if (comet.mmu.mem_max == 0) {

--- a/src/comet.h
+++ b/src/comet.h
@@ -135,6 +135,7 @@ typedef struct emulator_s {
 
     bool flag_debug;
     u64  flag_cycle_limit;
+    u64  flag_polling_rate;
     bool flag_no_color;
     bool flag_benchmark;
     char* flag_bin_path;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -826,15 +826,17 @@ void run() {
         push_interrupt(int_stack_underflow);
     }
 
-    if (comet.cpu.cycle % 4096 == 0) { // every 4096 cycles
-        int c;
-        if (kbhit()) {
-            c = fgetc(stdin);
-            if (c == 3 || c == 28) { // ctrl-c or ctrl-backslash
-                Exit();
+    if (comet.flag_polling_rate != 0) {
+        if (comet.cpu.cycle % comet.flag_polling_rate == 0) { // every 4096 cycles
+            int c;
+            if (kbhit()) {
+                c = fgetc(stdin);
+                if (c == 3 || c == 28) { // ctrl-c or ctrl-backslash
+                    Exit();
+                }
+                if (c == '\r') c = '\n';
+                send_in(11, c); // send in on port 11
             }
-            if (c == '\r') c = '\n';
-            send_in(11, c); // send in on port 11
         }
     }
 }

--- a/src/term.c
+++ b/src/term.c
@@ -1,5 +1,6 @@
 #include "orbit.h"
 #include "term.h"
+#include "comet.h"
 #include <stdlib.h>
 
 
@@ -14,13 +15,14 @@ static struct termios old;
 
 void term_setup(void) {
     if (is_term_set_up) return;
+    if (comet.flag_polling_rate != 0) {
+        tcgetattr(STDIN_FILENO, &old);
+        is_term_set_up = true;
 
-    tcgetattr(STDIN_FILENO, &old);
-    is_term_set_up = true;
-
-    struct termios cool_state = old;
-    cool_state.c_lflag &= (~ICANON & ~ECHO & ~IGNBRK); // ~IGNBRK ignores ctrl-c and stuff
-    tcsetattr(STDIN_FILENO, TCSANOW, &cool_state);
+        struct termios cool_state = old;
+        cool_state.c_lflag &= (~ICANON & ~ECHO & ~IGNBRK); // ~IGNBRK ignores ctrl-c and stuff
+        tcsetattr(STDIN_FILENO, TCSANOW, &cool_state);
+    }
 }
 
 void term_reset(void) {


### PR DESCRIPTION
add `-polling-rate:[rate]` arg, for changing the polling rate for user input. 4096 default, 0 means never poll. if its zero, the terminal is left in default state